### PR TITLE
New unittest imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: Run tests
           # This assumes pytest is installed via the install-package step above
-          command: python -m unittest src/tests/test_*
+          command: python -m unittest discover -s src/tests
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The model is tested with Python's [unittest](https://docs.python.org/3/library/u
 To locally test the model and/or any changes you make to the source code, set your working directory to the root of the project `py_SBeLT/` and run the following
 
 ```bash
-python3 -m unittest src/tests/test_*
+python3 -m unittest discover -s src/tests
 ```
 
 ## Submitting Changes

--- a/src/tests/test_logic.py
+++ b/src/tests/test_logic.py
@@ -10,7 +10,7 @@ import unittest
 import numpy as np
 from unittest.mock import Mock
 
-from ..sbelt import logic
+from src.sbelt import logic
 
 ATTR_COUNT = 7 # Number of attributes associated with a Particle
 # For reference:

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -8,7 +8,7 @@ Todo:
     A headache to resolve, but not impedeing functionality.
 """
 import unittest
-from ..sbelt import utils
+from src.sbelt import utils
 
 class TestValidateArguments(unittest.TestCase):
 


### PR DESCRIPTION
Update unittest test calls to address @pfeiffea's re-review comment regarding Import Errors when running wildcard unittest commands in Windows. This update should make the unittest command cross compatible between Linux and Windows.